### PR TITLE
exclude security_txt from no-entrypoint builds

### DIFF
--- a/contract/programs/ahoy-grants/src/lib.rs
+++ b/contract/programs/ahoy-grants/src/lib.rs
@@ -12,6 +12,7 @@ declare_id!("1212121212121212121212121212121212121212121");
 
 // This is particularly nice to include since explorer.solana.com picks it up and shows the info in
 // the UI.
+#[cfg(not(feature = "no-entrypoint"))]
 security_txt! {
     name: "Ahoy Grants",
     project_url: "https://summercamp.ahoy.fund",


### PR DESCRIPTION
The usage of `solana-security-txt` previously recommended in the official usage guide has an issue:

When multiple projects within a build, including dependencies, define a security-txt, the build fails.

To avoid this issue, library authors - including projects that *might* be used as a library by others in the future - should exclude the `security_txt` macro during `no-entrypoint` builds.

Feel free to read up on the details in [the issue on the security-txt repository](https://github.com/neodyme-labs/solana-security-txt/issues/11).

The [official usage guide](https://github.com/neodyme-labs/solana-security-txt#usage) has also been updated. This PR includes the recommended changes.
